### PR TITLE
Corrected mistake in english version

### DIFF
--- a/amivtex/kontakt.sty
+++ b/amivtex/kontakt.sty
@@ -145,7 +145,7 @@ The exhibitor may bring additional banners to use in replacement of the
 partitioning wall, as long as the booth's size is respected.
 }}
 
-\newcommand{\smallboothinfo}{ifgerman{%
+\newcommand{\smallboothinfo}{\ifgerman{%
 \bigbreak\noindent
 Standinformationen:
 \begin{enumerate}


### PR DESCRIPTION
In the english version, part of the german text was still displayed due to a typo (missing \ in front of 'ifgerman').